### PR TITLE
Fix installation problems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -168,5 +168,4 @@ device_check() {
   else
     abort "This module is only for Samsung Galaxy S5 Snapdragon 801 variants."
   fi
-  }
 }


### PR DESCRIPTION
So, it was a while before I remembered to do this when I was on a computer, but this is the cause of the bug that kept causing it to fail. Specifically, when trying to flash it would have an error stating "update-binary: /dev/tmp/install.sh: line 172: syntax error: unexpected "}""

Not sure if you want to increase the version in the module info or not for such a tiny fix, considering anyone who tried to install this using magisk manager would have errored out anyways for exactly the same reason.

Closes #1.